### PR TITLE
[DONE] Enter Membership Number by Scanning/Swiping Tests

### DIFF
--- a/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
@@ -85,8 +85,13 @@ public class MembershipControlTest {
 		ActionEvent e2 = new ActionEvent(this, 0, "correct");
 		mc.actionPerformed(e2);
 		assertTrue(mcStub.message.equals("12"));
-		
-		
+	}
+	
+	@Test
+	public void testActionPerformedCorrectZeroLength() {
+		ActionEvent e2 = new ActionEvent(this, 0, "correct");
+		mc.actionPerformed(e2);
+		assertTrue(mcStub.message.equals(""));
 	}
 	
 	@Test
@@ -98,6 +103,14 @@ public class MembershipControlTest {
 		ActionEvent e2 = new ActionEvent(this, 0, "submit");
 		mc.actionPerformed(e2);
 		assertTrue(mcStub.message.equals("Welcome! Itadori"));
+	}
+	
+	@Test
+	public void testActionPerformedSubmitEmptyNumber() {
+		ActionEvent e2 = new ActionEvent(this, 0, "submit");
+		mc.actionPerformed(e2);
+		assertNull(mcStub.message);
+		assertTrue(mcStub.membershipInput);
 	}
 	
 	@Test

--- a/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
@@ -93,10 +93,11 @@ public class MembershipControlTest {
 	public void testActionPerformedSubmit() {
 		ActionEvent e = new ActionEvent(this, 0, "MEMBER_INPUT_BUTTON: 1234");
 		mc.actionPerformed(e);
+		assertTrue(mcStub.message.equals("1234"));
 		
 		ActionEvent e2 = new ActionEvent(this, 0, "submit");
 		mc.actionPerformed(e2);
-		assertTrue(mcStub.message.equals("1234"));
+		assertTrue(mcStub.message.equals("Welcome! Itadori"));
 	}
 	
 	@Test

--- a/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/MembershipControlTest.java
@@ -14,6 +14,8 @@ import com.diy.software.fakedata.FakeDataInitializer;
 import com.diy.software.fakedata.MembershipDatabase;
 import com.diy.software.listeners.MembershipControlListener;
 
+import ca.powerutility.PowerGrid;
+
 public class MembershipControlTest {
 
 	public MembershipControl mc;
@@ -23,17 +25,14 @@ public class MembershipControlTest {
 
 	@Before
 	public void setUp() throws Exception {
+		PowerGrid.engageUninterruptiblePowerSource();
+		
 		fdi = new FakeDataInitializer();
 		sc = new StationControl(fdi);
 		mc = new MembershipControl(sc);
 		mcStub = new MembershipControlListenerStub();
 		
 		mc.addListener(mcStub);
-		
-		//MembershipDatabase.membershipMap.put(1234, "Itadori");
-		//MembershipDatabase.membershipMap.put(1235, "Customer1");
-		//MembershipDatabase.membershipMap.put(1236, "Customer2");
-		//MembershipDatabase.membershipMap.put(1237, "Customer3");
 	}
 
 	@After
@@ -41,14 +40,17 @@ public class MembershipControlTest {
 	}
 
 	@Test
-	public void testCheckMembership() {
+	public void testCheckMembershipCorrect() {
 		mc.checkMembership(1234);
 		assertTrue(mcStub.message.equals("Welcome! Itadori"));
-		
+		assertFalse(mcStub.membershipInput);
+	}
+	
+	@Test
+	public void testCheckMembershipIncorrect() {
 		mc.checkMembership(1239);
 		assertTrue(mcStub.message.equals("Member not found try again!"));
-		
-		
+		assertTrue(mcStub.membershipInput);
 	}
 	
 	@Test
@@ -56,10 +58,9 @@ public class MembershipControlTest {
 		
 		assertTrue(MembershipDatabase.membershipMap.containsKey(1234));
 		assertTrue(MembershipDatabase.membershipMap.get(1234).equals("Itadori"));
-		//assertNull(mcStub.message.equals("Welcome! Itadori"));
 		mc.checkMembership(1234);
 		assertTrue(mcStub.message.equals("Welcome! Itadori"));
-		//assertFalse(mc.checkMembership(-1));
+		assertFalse(mcStub.membershipInput);
 		
 	}
 	
@@ -68,8 +69,6 @@ public class MembershipControlTest {
 		ActionEvent e = new ActionEvent(this, 0, "MEMBER_INPUT_BUTTON: 123");
 		mc.actionPerformed(e);
 		assertTrue(mcStub.message.equals("123"));
-		
-		
 	}
 	
 	@Test
@@ -100,13 +99,18 @@ public class MembershipControlTest {
 		assertTrue(mcStub.message.equals("1234"));
 	}
 	
-	
-	
-	
+	@Test
+	public void testActionPerformedScanSwipeMembership() {
+		ActionEvent e = new ActionEvent(this, 0, "scan swipe membership");
+		mc.actionPerformed(e);
+		assertTrue(mcStub.scanSwipeSelected);
+	}
 	
 	public class MembershipControlListenerStub implements MembershipControlListener{
 
 		public String message;
+		public boolean scanSwipeSelected = false;
+		public boolean membershipInput = true;
 
 		@Override
 		public void welcomeMember(MembershipControl mc, String memberName) {
@@ -116,6 +120,18 @@ public class MembershipControlTest {
 		@Override
 		public void memberFieldHasBeenUpdated(MembershipControl mc, String memberNumber) {
 			message = memberNumber;
+			
+		}
+
+		@Override
+		public void scanSwipeSelected(MembershipControl mc) {
+			scanSwipeSelected = true;
+			
+		}
+
+		@Override
+		public void disableMembershipInput(MembershipControl mc) {
+			membershipInput = false;
 			
 		}
 		

--- a/com.diy.software.test/src/com/diy/software/test/logic/StubSystem.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/StubSystem.java
@@ -10,6 +10,7 @@ public class StubSystem implements StationControlListener{
 	boolean paymentStatus = false;
 	boolean triggerPaymentWorkflow = false;
 	public String paymentType;
+	boolean membershipCardInput = false;
 	
 
 	@Override
@@ -80,19 +81,19 @@ public class StubSystem implements StationControlListener{
 
 	@Override
 	public void startMembershipCardInput(StationControl systemControl) {
-		// TODO Auto-generated method stub
+		membershipCardInput = true;
 		
 	}
 
 	@Override
 	public void membershipCardInputFinished(StationControl systemControl) {
-		// TODO Auto-generated method stub
+		membershipCardInput = false;
 		
 	}
 
 	@Override
 	public void membershipCardInputCanceled(StationControl systemControl, String reason) {
-		// TODO Auto-generated method stub
+		membershipCardInput = false;
 		
 	}
 

--- a/com.diy.software.test/src/com/diy/software/test/logic/StubSystem.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/StubSystem.java
@@ -71,5 +71,47 @@ public class StubSystem implements StationControlListener{
 		// TODO Auto-generated method stub
 		
 	}
+
+	@Override
+	public void systemControlLocked(StationControl systemControl, boolean isLocked, String reason) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void startMembershipCardInput(StationControl systemControl) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void membershipCardInputFinished(StationControl systemControl) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void membershipCardInputCanceled(StationControl systemControl, String reason) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void triggerPurchaseBagsWorkflow(StationControl systemControl) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void noBagsInStock(StationControl systemControl) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void notEnoughBagsInStock(StationControl systemControl, int numBag) {
+		// TODO Auto-generated method stub
+		
+	}
 	
 }

--- a/com.diy.software.test/src/com/diy/software/test/logic/TestSystemControl.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/TestSystemControl.java
@@ -3,10 +3,13 @@ package com.diy.software.test.logic;
 import com.diy.software.util.Tuple;
 import com.diy.software.controllers.ItemsControl;
 import com.diy.software.controllers.StationControl;
+import com.diy.software.controllers.WalletControl;
 import com.diy.software.fakedata.FakeDataInitializer;
+import com.diy.software.listeners.WalletControlListener;
 import com.jimmyselectronics.necchi.Barcode;
 import com.jimmyselectronics.necchi.BarcodedItem;
 import com.jimmyselectronics.necchi.Numeral;
+import com.jimmyselectronics.opeechee.Card;
 
 import ca.powerutility.PowerGrid;
 
@@ -22,9 +25,11 @@ public class TestSystemControl {
 	private StationControl systemControl;
 	private FakeDataInitializer fdi;
 	private StubSystem stub;
+	private WalletStub wStub;
 	Barcode[] barcodes;
 	BarcodedItem[] items;
 	private ItemsControl ic;
+	private Card membershipCard;
 	
 	@Before
 	public void setup() {
@@ -34,12 +39,17 @@ public class TestSystemControl {
 		barcodes = fdi.getBarcodes();
 		items = fdi.getItems();
 		
+		membershipCard = fdi.getCards()[3];
+		
 		PowerGrid.engageUninterruptiblePowerSource();
 		
 		systemControl = new StationControl();
 		stub = new StubSystem();
 		systemControl.register(stub);
 		ic = systemControl.getItemsControl();
+		
+		wStub = new WalletStub();
+		systemControl.getWalletControl().addListener(wStub);
 	}
 	
 	
@@ -158,6 +168,37 @@ public class TestSystemControl {
 		//systemControl.unblockStation();
 	}*/
 	
+	@Test
+	public void testCardDataReadMembership() {
+		//TODO
+		//systemControl.cardDataRead(, null);
+	}
+	
+	@Test
+	public void testBarcodeScannedMembership() {
+		//TODO
+	}
+	
+	@Test
+	public void startMembershipCardInput() {
+		systemControl.startMembershipCardInput();
+		assertTrue(wStub.membershipCardInputEnabled);
+	}
+	
+	@Test
+	public void testCancelMembershipCardInput() {
+		wStub.membershipCardInputEnabled = true;
+		systemControl.cancelMembershipCardInput();
+		assertFalse(wStub.membershipCardInputEnabled);
+	}
+	
+	@Test
+	public void triggerMembershipCardInputFailScreen() {
+		wStub.membershipCardInputEnabled = true;
+		systemControl.triggerMembershipCardInputFailScreen("message");
+		assertFalse(wStub.membershipCardInputEnabled);
+	}
+	
 	@After
 	public void teardown() {
 		PowerGrid.reconnectToMains();
@@ -172,4 +213,66 @@ public class TestSystemControl {
 		}
 	}
 	
+	public class WalletStub implements WalletControlListener{
+
+		public boolean cardHasBeenSelected = false;
+		public boolean paymentsEnabled = false;
+		public boolean inserted = false;
+		public boolean membershipCardSelected = false;
+		public boolean membershipCardInputEnabled = false;
+
+		@Override
+		public void cardHasBeenSelected(WalletControl wc) {
+			cardHasBeenSelected = true;
+			
+		}
+
+		@Override
+		public void cardPaymentsEnabled(WalletControl wc) {
+			paymentsEnabled = true;
+			
+		}
+
+		@Override
+		public void cardPaymentsDisabled(WalletControl wc) {
+			paymentsEnabled = false;
+			
+		}
+
+		@Override
+		public void cardHasBeenInserted(WalletControl wc) {
+			
+		}
+
+		@Override
+		public void cardWithPinInserted(WalletControl wc) {
+			inserted = true;
+			
+		}
+
+		@Override
+		public void cardWithPinRemoved(WalletControl wc) {
+			inserted = false;
+			
+		}
+
+		@Override
+		public void membershipCardHasBeenSelected(WalletControl wc) {
+			membershipCardSelected = true;
+			
+		}
+
+		@Override
+		public void membershipCardInputEnabled(WalletControl wc) {
+			membershipCardInputEnabled = true;
+			
+		}
+
+		@Override
+		public void membershipCardInputCanceled(WalletControl walletControl) {
+			membershipCardInputEnabled = false;
+			
+		}
+		
+	}
 }

--- a/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
@@ -9,10 +9,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.diy.software.controllers.MembershipControl;
 import com.diy.software.controllers.StationControl;
 import com.diy.software.controllers.WalletControl;
 import com.diy.software.fakedata.FakeDataInitializer;
+import com.diy.software.listeners.MembershipControlListener;
 import com.diy.software.listeners.WalletControlListener;
+import com.diy.software.test.logic.MembershipControlTest.MembershipControlListenerStub;
 import com.jimmyselectronics.AbstractDevice;
 import com.jimmyselectronics.AbstractDeviceListener;
 import com.jimmyselectronics.opeechee.Card;
@@ -31,6 +34,7 @@ public class WalletControlTest {
 	Card card3;
 	Card card4;
 	WalletStub wStub;
+	MembershipStub mcStub;
 
 	@Before
 	public void setUp() throws Exception {
@@ -41,6 +45,9 @@ public class WalletControlTest {
 		sc = new StationControl(fdi);
 		wc = new WalletControl(sc); 
 		readStub = new ReaderStub();
+		
+		mcStub = new MembershipStub();
+		sc.getMembershipControl().addListener(mcStub);
 		
 		sc.station.cardReader.deregisterAll();
 		sc.station.cardReader.register(readStub);
@@ -445,6 +452,21 @@ public class WalletControlTest {
 		assertFalse(wStub.inserted);
 	}
 	
+	/*
+	 * TODO:
+	 *  - scanCard()
+	 *  	- successfulScan
+	 *      - unsuccessfulScan
+	 *  - toByteDigit()
+	 *  	- 0-9 and then smth else
+	 *  - actionPerformed()
+	 *  	- "m"
+	 *  	- "scan"
+	 *  - membershipCardInputEnabled()
+	 *  - membershipCardInputCanceled()
+	 *  	-> Need membership controller stub
+	 */
+	
 	@After
 	public void teardown() {
 		PowerGrid.reconnectToMains();
@@ -576,6 +598,37 @@ public class WalletControlTest {
 		@Override
 		public void membershipCardInputCanceled(WalletControl walletControl) {
 			membershipCardInputEnabled = false;
+			
+		}
+		
+	}
+	
+	public class MembershipStub implements MembershipControlListener{
+
+		public String message;
+		public boolean scanSwipeSelected = false;
+		public boolean membershipInput = true;
+
+		@Override
+		public void welcomeMember(MembershipControl mc, String memberName) {
+			message = memberName;
+		}
+
+		@Override
+		public void memberFieldHasBeenUpdated(MembershipControl mc, String memberNumber) {
+			message = memberNumber;
+			
+		}
+
+		@Override
+		public void scanSwipeSelected(MembershipControl mc) {
+			scanSwipeSelected = true;
+			
+		}
+
+		@Override
+		public void disableMembershipInput(MembershipControl mc) {
+			membershipInput = false;
 			
 		}
 		

--- a/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
@@ -29,6 +29,7 @@ public class WalletControlTest {
 	Card card1;
 	Card card2;
 	Card card3;
+	Card card4;
 	WalletStub wStub;
 
 	@Before
@@ -47,6 +48,7 @@ public class WalletControlTest {
 		card1 = cards[0];
 		card2 = cards[1];
 		card3 = cards[2];
+		card4 = cards[3];
 		sc.customer.wallet.cards.clear();
 		sc.customer.wallet.cards.add(card1);
 		wStub = new WalletStub();
@@ -125,6 +127,18 @@ public class WalletControlTest {
 		wc.selectCard("VISA");
 		assertTrue(sc.customer.wallet.cards.contains(card1));
 		assertFalse(sc.customer.wallet.cards.contains(card2));
+		
+	}
+	
+	@Test
+	public void testSelectCardMembership() {
+		sc.customer.wallet.cards.add(card4);
+		wc.addListener(wStub);
+		
+		assertTrue(sc.customer.wallet.cards.contains(card4));
+		wc.selectCard("MEMBERSHIP");
+		assertFalse(sc.customer.wallet.cards.contains(card4));
+		assertTrue(wStub.membershipCardSelected);
 		
 	}
 	
@@ -509,6 +523,8 @@ public class WalletControlTest {
 		public boolean cardHasBeenSelected = false;
 		public boolean paymentsEnabled = false;
 		public boolean inserted = false;
+		public boolean membershipCardSelected = false;
+		public boolean membershipCardInputEnabled = false;
 
 		@Override
 		public void cardHasBeenSelected(WalletControl wc) {
@@ -542,6 +558,24 @@ public class WalletControlTest {
 		@Override
 		public void cardWithPinRemoved(WalletControl wc) {
 			inserted = false;
+			
+		}
+
+		@Override
+		public void membershipCardHasBeenSelected(WalletControl wc) {
+			membershipCardSelected = true;
+			
+		}
+
+		@Override
+		public void membershipCardInputEnabled(WalletControl wc) {
+			membershipCardInputEnabled = true;
+			
+		}
+
+		@Override
+		public void membershipCardInputCanceled(WalletControl walletControl) {
+			membershipCardInputEnabled = false;
 			
 		}
 		

--- a/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
@@ -21,6 +21,7 @@ import com.jimmyselectronics.AbstractDeviceListener;
 import com.jimmyselectronics.necchi.Barcode;
 import com.jimmyselectronics.necchi.BarcodeScanner;
 import com.jimmyselectronics.necchi.BarcodeScannerListener;
+import com.jimmyselectronics.necchi.IllegalDigitException;
 import com.jimmyselectronics.opeechee.Card;
 import com.jimmyselectronics.opeechee.Card.CardData;
 import com.jimmyselectronics.opeechee.CardReader;
@@ -496,15 +497,21 @@ public class WalletControlTest {
 		assertTrue(mcStub.membershipInput);
 	}
 	
-	/*
-	 * TODO:
-	 *  - actionPerformed()
-	 *  	- "scan"
-	 *  		- scan successful/unsuccessful
-	 *  		- all digits/ not a digit
-	 *  - membershipCardInputEnabled()
-	 *  - membershipCardInputCanceled()
-	 */
+	@Test
+	public void testActionPerformedScanInvalidNumber() {
+		wc.addListener(wStub);
+		sc.customer.wallet.cards.add(new Card("MEMBERSHIP", "1234567890a", "Name", "000", "0000", false, true));
+		ActionEvent e = new ActionEvent(this, 0, "m");
+		wc.actionPerformed(e);
+		
+		sc.startMembershipCardInput();
+		
+		ActionEvent e2 = new ActionEvent(this, 0, "scan");
+		wc.actionPerformed(e2);
+		
+		assertNull(mcStub.memberName);
+		assertTrue(mcStub.membershipInput);
+	}
 	
 	
 	@Test

--- a/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
+++ b/com.diy.software.test/src/com/diy/software/test/logic/WalletControlTest.java
@@ -18,6 +18,9 @@ import com.diy.software.listeners.WalletControlListener;
 import com.diy.software.test.logic.MembershipControlTest.MembershipControlListenerStub;
 import com.jimmyselectronics.AbstractDevice;
 import com.jimmyselectronics.AbstractDeviceListener;
+import com.jimmyselectronics.necchi.Barcode;
+import com.jimmyselectronics.necchi.BarcodeScanner;
+import com.jimmyselectronics.necchi.BarcodeScannerListener;
 import com.jimmyselectronics.opeechee.Card;
 import com.jimmyselectronics.opeechee.Card.CardData;
 import com.jimmyselectronics.opeechee.CardReader;
@@ -452,6 +455,11 @@ public class WalletControlTest {
 		assertFalse(wStub.inserted);
 	}
 	
+	@Test
+	public void testScanCardSuccessful() {
+		
+	}
+	
 	/*
 	 * TODO:
 	 *  - scanCard()
@@ -538,6 +546,44 @@ public class WalletControlTest {
 			cd = data;
 			
 		}
+	}
+	
+	public class ScannerStub implements BarcodeScannerListener{
+		
+		public boolean enabled = false;
+		public boolean turnedOn = false;
+		public boolean barcodeScanned = false;
+
+		@Override
+		public void enabled(AbstractDevice<? extends AbstractDeviceListener> device) {
+			enabled = true;
+			
+		}
+
+		@Override
+		public void disabled(AbstractDevice<? extends AbstractDeviceListener> device) {
+			enabled = false;
+			
+		}
+
+		@Override
+		public void turnedOn(AbstractDevice<? extends AbstractDeviceListener> device) {
+			turnedOn = true;
+			
+		}
+
+		@Override
+		public void turnedOff(AbstractDevice<? extends AbstractDeviceListener> device) {
+			turnedOn = false;
+			
+		}
+
+		@Override
+		public void barcodeScanned(BarcodeScanner barcodeScanner, Barcode barcode) {
+			barcodeScanned = true;
+			
+		}
+		
 	}
 	
 	public class WalletStub implements WalletControlListener{

--- a/com.diy.software/src/com/diy/software/controllers/MembershipControl.java
+++ b/com.diy.software/src/com/diy/software/controllers/MembershipControl.java
@@ -66,7 +66,7 @@ public class MembershipControl implements ActionListener {
 						l.memberFieldHasBeenUpdated(this, memberNumber);
 					break;
 				case "submit":
-					if (memberNumber != null && !memberNumber.isEmpty()) {
+					if (!memberNumber.isEmpty()) {
 						int memNum = Integer.parseInt(memberNumber);
 						checkMembership(memNum);
 					}

--- a/com.diy.software/src/com/diy/software/controllers/StationControl.java
+++ b/com.diy.software/src/com/diy/software/controllers/StationControl.java
@@ -201,6 +201,10 @@ public class StationControl
 		return cc;
 	}
 	
+	public DoItYourselfStation getStation() {
+		return station;
+	}
+	
 	private void loadBags() {
 		try {
 			for(int i = 0; i < bagInStock; i++) {


### PR DESCRIPTION
 - Added unimplemented methods in Membership, Wallet, and StubSystem stubs
 - Added tests in MembershipControlTests -> full coverage
 - Added tests in WalletControlTests
- Added tests in StationControl

Additional Changes:
 - Added getStation() in StationControl
 - Removed a `memberNumber!=null ` check because memberNumber is never null